### PR TITLE
Fix collection plan PHP errors when UUID not correctly configured

### DIFF
--- a/params.distrib.xml
+++ b/params.distrib.xml
@@ -33,7 +33,7 @@
 	<synchro_user>admin</synchro_user>
 	<json_placeholders>
 		<!-- IP Discovery Application UUID -->
-		<discovery_application_uuid>1234767</discovery_application_uuid>
+		<discovery_application_uuid>0123_4567_89AB_CDEF</discovery_application_uuid>
 		<!-- Name of synchronization data sources -->
 		<ipv4_synchro_name>TeemIp IPv4 Discovery</ipv4_synchro_name>
 		<subnetv4_synchro_name>TeemIp IPv4 Subnet Discovery</subnetv4_synchro_name>

--- a/src/TeemIpDiscoveryCollectionPlan.class.inc.php
+++ b/src/TeemIpDiscoveryCollectionPlan.class.inc.php
@@ -107,7 +107,7 @@ class TeemIpDiscoveryCollectionPlan extends CollectionPlan
 				Utils::Log(LOG_INFO, "IP Discovery Application has UUID ".$this->aDiscoveryApplication['UUID'].".");
 			} else {
 				$this->aDiscoveryApplication['UUID'] = '';
-				Utils::Log(LOG_INFO, "Discovery can not proceed as no IP Discovery Application UUID has been defined.");
+				Utils::Log(LOG_ERR, "Discovery can not proceed as no IP Discovery Application UUID has been defined.");
 			}
 
 			// Get discovery parameters


### PR DESCRIPTION
When the UUID not exists:
```
[Info]	---------- Build collection plan ----------
[Info]	---------- Check TeemIp installation ----------
[Info]	TeemIp is installed
[Info]	TeemIp IP Discovery is installed
[Info]	TeemIp Network Management Extended is installed
[Info]	TeemIp Zone Management extension is NOT installed
[Info]	IP Discovery Application has UUID 1234767.
[Warning]	There is no IP Discovery Application with UUID 1234767 in iTop.
[Error] It has not been possible to retrieve working parameters. Discovery process must stop here !
```
Was:
```
[Info]	---------- Build collection plan ----------
[Info]	---------- Check TeemIp installation ----------
[Info]	TeemIp is installed
[Info]	TeemIp IP Discovery is installed
[Info]	TeemIp Network Management Extended is installed
[Info]	TeemIp Zone Management extension is NOT installed
[Info]	IP Discovery Application has UUID 1234767.
PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in /home/u0306008/var/teemip-ip-discovery-collector/collectors/src/TeemIpDiscoveryCollectionPlan.class.inc.php:141
Stack trace:
#0 /home/u0306008/var/teemip-ip-discovery-collector/collectors/src/TeemIpDiscoveryCollectionPlan.class.inc.php(115): TeemIpDiscoveryCollectionPlan->GetDiscoveryParameters('1234767')
#1 /home/u0306008/var/teemip-ip-discovery-collector/core/orchestrator.class.inc.php(59): TeemIpDiscoveryCollectionPlan->Init()
#2 /home/u0306008/var/teemip-ip-discovery-collector/collectors/main.php(10): Orchestrator::UseCollectionPlan('TeemIpDiscovery...')
#3 /home/u0306008/var/teemip-ip-discovery-collector/exec.php(84): require_once('/home/u0306008/...')
#4 {main}
  thrown in /home/u0306008/var/teemip-ip-discovery-collector/collectors/src/TeemIpDiscoveryCollectionPlan.class.inc.php on line 141
```

When empty UUID configured:
```
[Info]	---------- Build collection plan ----------
[Info]	---------- Check TeemIp installation ----------
[Info]	TeemIp is installed
[Info]	TeemIp IP Discovery is installed
[Info]	TeemIp Network Management Extended is installed
[Info]	TeemIp Zone Management extension is NOT installed
[Error]	Discovery can not proceed as no IP Discovery Application UUID has been defined.
```
Was:
```
[Info]	---------- Build collection plan ----------
[Info]	---------- Check TeemIp installation ----------
[Info]	TeemIp is installed
[Info]	TeemIp IP Discovery is installed
[Info]	TeemIp Network Management Extended is installed
[Info]	TeemIp Zone Management extension is NOT installed
[Info]	IP Discovery Application has UUID .
PHP Warning:  Undefined array key "params" in /home/u0306008/var/teemip-ip-discovery-collector/collectors/src/TeemIpDiscoveryCollectionPlan.class.inc.php on line 355
PHP Fatal error:  Uncaught TypeError: TeemIpDiscoveryCollectionPlan::GetSubnetsList(): Return value must be of type array, null returned in /home/u0306008/var/teemip-ip-discovery-collector/collectors/src/TeemIpDiscoveryCollectionPlan.class.inc.php:370
Stack trace:
#0 /home/u0306008/var/teemip-ip-discovery-collector/collectors/src/TeemIpDiscoveryIPv4Collector.class.inc.php(36): TeemIpDiscoveryCollectionPlan->GetSubnetsList('ipv4')
#1 /home/u0306008/var/teemip-ip-discovery-collector/core/collectionplan.class.inc.php(137): TeemIpDiscoveryIPv4Collector->Init()
#2 /home/u0306008/var/teemip-ip-discovery-collector/core/orchestrator.class.inc.php(60): CollectionPlan->AddCollectorsToOrchestrator()
#3 /home/u0306008/var/teemip-ip-discovery-collector/collectors/main.php(10): Orchestrator::UseCollectionPlan('TeemIpDiscovery...')
#4 /home/u0306008/var/teemip-ip-discovery-collector/exec.php(84): require_once('/home/u0306008/...')
#5 {main}
  thrown in /home/u0306008/var/teemip-ip-discovery-collector/collectors/src/TeemIpDiscoveryCollectionPlan.class.inc.php on line 370
```