### PR TITLE
Change IP Discovery Application synchro to use the primary_key as reconciliation

### DIFF
--- a/json/TeemIpDiscoveryIPApplicationCollector.json
+++ b/json/TeemIpDiscoveryIPApplicationCollector.json
@@ -8,7 +8,7 @@
 	"database_table_name": "synchro_data_ipapplication_$discovery_application_uuid$",
 	"scope_restriction": "",
 	"full_load_periodicity": "0",
-	"reconciliation_policy": "use_attributes",
+	"reconciliation_policy": "use_primary_key",
 	"action_on_zero": "error",
 	"action_on_one": "update",
 	"action_on_multiple": "error",
@@ -226,8 +226,8 @@
 		},
 		{
 			"attcode": "uuid",
-			"update": "0",
-			"reconcile": "1",
+			"update": "1",
+			"reconcile": "0",
 			"update_policy": "master_locked",
 			"finalclass": "SynchroAttribute"
 		}

--- a/json/TeemIpDiscoveryIPApplicationCollector.json
+++ b/json/TeemIpDiscoveryIPApplicationCollector.json
@@ -226,7 +226,7 @@
 		},
 		{
 			"attcode": "uuid",
-			"update": "1",
+			"update": "0",
 			"reconcile": "0",
 			"update_policy": "master_locked",
 			"finalclass": "SynchroAttribute"

--- a/src/TeemIpDiscoveryCollectionPlan.class.inc.php
+++ b/src/TeemIpDiscoveryCollectionPlan.class.inc.php
@@ -180,6 +180,7 @@ class TeemIpDiscoveryCollectionPlan extends CollectionPlan
 						Utils::Log(LOG_INFO, "An IP Discovery Application with UUID ".$sApplicationUUID." has been found in iTop.");
 						$aData = reset($aResult['objects']);
 						$aIPDiscoveryAttributes = $aData['fields'];
+						$aIPDiscoveryAttributes['id'] = (int) $aData['key'];
 
 						foreach ($aIPDiscoveryAttributes['ipv4subnets_list'] as $sSubnetKey => $aIPv4Subnet) {
 							$sIndex = $aIPv4Subnet['ip'];
@@ -386,6 +387,9 @@ class TeemIpDiscoveryCollectionPlan extends CollectionPlan
 	public function GetApplicationParam($sParam)
 	{
 		switch ($sParam) {
+			case 'id':
+				return $this->aDiscoveryApplication['params']['id'];
+				
 			case 'uuid':
 				return $this->aDiscoveryApplication['UUID'];
 

--- a/src/TeemIpDiscoveryIPApplicationCollector.class.inc.php
+++ b/src/TeemIpDiscoveryIPApplicationCollector.class.inc.php
@@ -87,15 +87,14 @@ class TeemIpDiscoveryIPApplicationCollector extends Collector
 
 	/**
 	 * @inheritdoc
-	 * @return array{ primary_key: int, uuid: string, last_discovery_date: string, duration:int }|false
+	 * @return array{ primary_key: int, last_discovery_date: string, duration:int }|false
 	 */
-	public function fetch()
+	public function Fetch()
 	{
 		if ($this->iIndex < static::MAX_IP_APPS) {
 			$this->iIndex++;
 			return [
 				'primary_key' => $this->oCollectionPlan->GetApplicationParam('id'),
-				'uuid' => $this->oCollectionPlan->GetApplicationParam('uuid'),
 				'last_discovery_date' => $this->oCollectionPlan->GetApplicationParam('last_discovery_date'),
 				'duration' => $this->oCollectionPlan->GetApplicationParam('duration')
 			];

--- a/src/TeemIpDiscoveryIPApplicationCollector.class.inc.php
+++ b/src/TeemIpDiscoveryIPApplicationCollector.class.inc.php
@@ -9,7 +9,7 @@ class TeemIpDiscoveryIPApplicationCollector extends Collector
 	const MAX_IP_APPS = 1;
 
 	protected $iIndex;
-	protected $oCollectionPlan;
+	protected TeemIpDiscoveryCollectionPlan $oCollectionPlan;
 
 	/**
 	 * @inheritdoc
@@ -87,18 +87,18 @@ class TeemIpDiscoveryIPApplicationCollector extends Collector
 
 	/**
 	 * @inheritdoc
+	 * @return array{ primary_key: int, uuid: string, last_discovery_date: string, duration:int }|false
 	 */
 	public function fetch()
 	{
 		if ($this->iIndex < static::MAX_IP_APPS) {
-			$aDatas = array();
-			$aDatas['primary_key'] = $this->oCollectionPlan->GetApplicationParam('uuid');
-			$aDatas['uuid'] = $this->oCollectionPlan->GetApplicationParam('uuid');
-			$aDatas['last_discovery_date'] = $this->oCollectionPlan->GetApplicationParam('last_discovery_date');
-			$aDatas['duration'] = $this->oCollectionPlan->GetApplicationParam('duration');
 			$this->iIndex++;
-
-			return $aDatas;
+			return [
+				'primary_key' => $this->oCollectionPlan->GetApplicationParam('id'),
+				'uuid' => $this->oCollectionPlan->GetApplicationParam('uuid'),
+				'last_discovery_date' => $this->oCollectionPlan->GetApplicationParam('last_discovery_date'),
+				'duration' => $this->oCollectionPlan->GetApplicationParam('duration')
+			];
 		}
 
 		return false;


### PR DESCRIPTION
Not tested yet, this is a PoC to see if @xtophe38 would agree with this taken approach.