### PR TITLE
Fix fping command to not output stderr

### DIFF
--- a/src/TeemIpDiscoveryIPv4Collector.class.inc.php
+++ b/src/TeemIpDiscoveryIPv4Collector.class.inc.php
@@ -230,7 +230,7 @@ class TeemIpDiscoveryIPv4Collector extends Collector
 				Utils::Log(LOG_INFO, "Start to ping subnet: ".$sSubnetIp);
 
 				// fping if available
-				if (isset($sFpingCmd)) exec(sprintf('%s -r1 -t%d -ga %s %s', $sFpingCmd, $iTimeOut*1000, long2ip($iIp), long2ip($iBroadcastIp-1)), $aFPingResults);
+				if (isset($sFpingCmd)) exec(sprintf('%s -r1 -t%d -ga %s %s 2>&1', $sFpingCmd, $iTimeOut*1000, long2ip($iIp), long2ip($iBroadcastIp-1)), $aFPingResults);
 
 				while ($iIp < $iBroadcastIp) {
 					$sIp = long2ip($iIp);


### PR DESCRIPTION
In some situations, `fping` is outputting messages to `stderr` stream which is not covered by `exec`, so it would result in the following logs:

> ```
> [2024-04-03 11:21:47]   [Debug] ---------------------------------------------
> [2024-04-03 11:21:47]   [Info]  Start to ping subnet: 10.35.9.0
> ICMP Network Unreachable from 172.31.5.1 for ICMP Echo sent to 10.35.9.49
> [2024-04-03 11:21:58]   [Debug] Ping 10.35.9.1 -> OK
> [2024-04-03 11:21:58]   [Debug] Ping 10.35.9.2 -> OK
> ...
> ```

After this change:

> ```
> [2024-04-03 11:21:47]   [Debug] ---------------------------------------------
> [2024-04-03 11:21:47]   [Info]  Start to ping subnet: 10.35.9.0
> [2024-04-03 11:21:58]   [Debug] Ping 10.35.9.1 -> OK
> [2024-04-03 11:21:58]   [Debug] Ping 10.35.9.2 -> OK
> ...
> ```