### PR TITLE
Fix collector overwriting IPv4Address status field

### DIFF
--- a/json/TeemIpDiscoveryIPv4Collector.json
+++ b/json/TeemIpDiscoveryIPv4Collector.json
@@ -191,7 +191,7 @@
       "attcode": "status",
       "update": "1",
       "reconcile": "0",
-      "update_policy": "master_unlocked",
+      "update_policy": "write_if_empty",
       "finalclass": "SynchroAttribute"
     },
     {


### PR DESCRIPTION
If you update an address while the collector is running, for example setting to status _Reserved_ or assign it to a device, then the collector will revert the status to the previous value at end of the run.

This change prevents this and only sets the status on creation of the object.